### PR TITLE
capture raven exceptions correctly

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -77,7 +77,7 @@ Raven
 
 export class RavenErrorHandler implements ErrorHandler {
     handleError(err: any): void {
-        Raven.captureException(err.originalError);
+        Raven.captureException(err);
         console.error(err);
     }
 }


### PR DESCRIPTION
### What
Capture the wrapped error from Angular 2

### Why
Most of our Sentry errors were undefined 