### PR TITLE
ensure null annotations and stats are handled

### DIFF
--- a/src/app/components/pages/variant/variant.component.html
+++ b/src/app/components/pages/variant/variant.component.html
@@ -73,7 +73,7 @@
                                     <span>Frequency:</span>
                                 </div>
                                 <div class="detail-value">
-                                    <span>{{ variant.variantStats[0].altAlleleFreq.toExponential(4) }}</span>
+                                    <span *ngIf="variant.variantStats[0]">{{ variant.variantStats[0].altAlleleFreq.toExponential(4) }}</span>
                                 </div>
                             </div>
 
@@ -132,67 +132,70 @@
                             <md-progress-bar [mode]="'determinate'"
                                              [value]="beacons.percentComplete()"></md-progress-bar>
 
-                            <app-beacon-table *ngIf="showBeacon && beacons" [beacons]="beacons" [minimal]="true" [limit]="10"></app-beacon-table>
+                            <app-beacon-table *ngIf="showBeacon && beacons" [beacons]="beacons" [minimal]="true"
+                                              [limit]="10"></app-beacon-table>
                         </div>
                     </div>
                 </div>
             </div>
 
-            <div class="detail-type">Annotations</div>
+            <div *ngIf="variant.annotation">
+                <div class="detail-type">Annotations</div>
 
-            <div class="group">
-                <div class="subgroup">
-                    <div class="card">
-                        <div class="card-row" (click)="toggleConsequence()" *ngIf="consequences">
-                            <div>
-                                <span class="highlight-number">{{ consequences.types.length }}</span>
-                                <span>Consequences</span>
+                <div class="group">
+                    <div class="subgroup">
+                        <div class="card">
+                            <div class="card-row" (click)="toggleConsequence()" *ngIf="consequences">
+                                <div>
+                                    <span class="highlight-number">{{ consequences.types.length }}</span>
+                                    <span>Consequences</span>
+                                </div>
+                                <md-icon *ngIf="!showConsequence">keyboard_arrow_down</md-icon>
+                                <md-icon *ngIf="showConsequence">keyboard_arrow_up</md-icon>
                             </div>
-                            <md-icon *ngIf="!showConsequence">keyboard_arrow_down</md-icon>
-                            <md-icon *ngIf="showConsequence">keyboard_arrow_up</md-icon>
+                            <app-consequences [hidden]="!showConsequence" [variant]="variant"></app-consequences>
                         </div>
-                        <app-consequences [hidden]="!showConsequence" [variant]="variant"></app-consequences>
+
                     </div>
-
                 </div>
-            </div>
 
-            <div class="group">
-                <div class="subgroup">
-                    <div class="card">
-                        <div class="card-row" (click)="toggleScores()" *ngIf="scores">
-                            <div>
-                                <span class="highlight-number">{{ scores.scores.length }}</span>
-                                <span>Scores</span>
+                <div class="group">
+                    <div class="subgroup">
+                        <div class="card">
+                            <div class="card-row" (click)="toggleScores()" *ngIf="scores">
+                                <div>
+                                    <span class="highlight-number">{{ scores.scores.length }}</span>
+                                    <span>Scores</span>
+                                </div>
+                                <md-icon *ngIf="!showScores">keyboard_arrow_down</md-icon>
+                                <md-icon *ngIf="showScores">keyboard_arrow_up</md-icon>
                             </div>
-                            <md-icon *ngIf="!showScores">keyboard_arrow_down</md-icon>
-                            <md-icon *ngIf="showScores">keyboard_arrow_up</md-icon>
+                            <app-scores [hidden]="!showScores" [variant]="variant"></app-scores>
                         </div>
-                        <app-scores [hidden]="!showScores" [variant]="variant"></app-scores>
+
                     </div>
-
                 </div>
-            </div>
 
-            <div class="group">
-                <div class="subgroup">
-                    <div class="card">
-                        <div class="card-row" (click)="togglePopFreq()" *ngIf="popFreq">
-                            <div>
-                                <span class="highlight-number">{{ popFreq.studies.size }}</span>
-                                <span>Population studies</span>
+                <div class="group">
+                    <div class="subgroup">
+                        <div class="card">
+                            <div class="card-row" (click)="togglePopFreq()" *ngIf="popFreq">
+                                <div>
+                                    <span class="highlight-number">{{ popFreq.studies.size }}</span>
+                                    <span>Population studies</span>
+                                </div>
+                                <md-icon *ngIf="!showPopFreq">keyboard_arrow_down</md-icon>
+                                <md-icon *ngIf="showPopFreq">keyboard_arrow_up</md-icon>
                             </div>
-                            <md-icon *ngIf="!showPopFreq">keyboard_arrow_down</md-icon>
-                            <md-icon *ngIf="showPopFreq">keyboard_arrow_up</md-icon>
+                            <app-pop-freqs [hidden]="!showPopFreq" [variant]="variant"></app-pop-freqs>
                         </div>
-                        <app-pop-freqs [hidden]="!showPopFreq" [variant]="variant"></app-pop-freqs>
+
                     </div>
-
                 </div>
-            </div>
 
-            <div class="group" *ngIf="showAnnotations">
-                <app-variant-annotations [annotations]="variant.annotation"></app-variant-annotations>
+                <div class="group" *ngIf="showAnnotations">
+                    <app-variant-annotations [annotations]="variant.annotation"></app-variant-annotations>
+                </div>
             </div>
 
         </div>

--- a/src/app/components/parts/consequences/consequences.component.ts
+++ b/src/app/components/parts/consequences/consequences.component.ts
@@ -21,7 +21,7 @@ export class ConsequencesComponent implements OnInit, AfterViewInit {
     }
 
     ngOnInit() {
-        this.types = this.variant.annotation.consequenceTypes;
+        this.types = this.variant.annotation.consequenceTypes ? this.variant.annotation.consequenceTypes : [];
     }
 
     ngAfterViewInit() {

--- a/src/app/components/parts/pop-freqs/pop-freqs.component.ts
+++ b/src/app/components/parts/pop-freqs/pop-freqs.component.ts
@@ -21,7 +21,10 @@ export class PopFreqsComponent implements OnInit {
     }
 
     ngOnInit() {
-        this.freqs = this.variant.annotation.populationFrequencies;
+        if (!this.variant.annotation) {
+            return;
+        }
+        this.freqs = this.variant.annotation.populationFrequencies ? this.variant.annotation.populationFrequencies : [];
         this.studies = new Set(this.freqs.map((f) => f.study).sort());
         this.populations = new Set(this.freqs.map((f) => f.population));
         this.studies.forEach((s) => {

--- a/src/app/components/parts/scores/scores.component.ts
+++ b/src/app/components/parts/scores/scores.component.ts
@@ -15,7 +15,12 @@ export class ScoresComponent implements OnInit {
     }
 
     ngOnInit() {
-        this.variant.annotation.functionalScore.forEach((s) => this.scores.push(s));
-        this.variant.annotation.conservation.forEach((s) => this.scores.push(s));
+        if (this.variant.annotation.functionalScore) {
+            this.variant.annotation.functionalScore.forEach((s) => this.scores.push(s));
+        }
+
+        if (this.variant.annotation.conservation) {
+            this.variant.annotation.conservation.forEach((s) => this.scores.push(s));
+        }
     }
 }

--- a/src/app/components/parts/variants-table/variants-table.component.html
+++ b/src/app/components/parts/variants-table/variants-table.component.html
@@ -31,7 +31,7 @@
                     <span *ngIf="label !== 'Allele Scale' && label !== 'Location'"
                           class="value">{{ columnService.display(label, variant) }}</span>
                     <a *ngIf="label === 'Location'" target="_blank" [href]="variantUrl(variant)">{{ columnService.display(label, variant) }}</a>
-                    <app-allele-freq *ngIf="label === 'Allele Scale'"
+                    <app-allele-freq *ngIf="label === 'Allele Scale' && variant.variantStats[0]"
                                      [freq]="variant.variantStats[0].altAlleleFreq"></app-allele-freq>
                 </td>
             </tr>

--- a/src/app/components/parts/variants-table/variants-table.component.ts
+++ b/src/app/components/parts/variants-table/variants-table.component.ts
@@ -95,11 +95,11 @@ export class VariantsTableComponent implements OnInit, OnDestroy, AfterViewInit 
                 'Reference': variant.reference,
                 'Alternate': variant.alternate,
                 'Type': variant.type,
-                'Homozygotes Count': variant.variantStats[0].genotypesCount[HOMOZYGOTES_KEY],
-                'Heterozygotes Count': variant.variantStats[0].genotypesCount[HETEROZYGOTES_KEY],
-                'Missed Genotypes': variant.variantStats[0].genotypesCount[MISSED_GENOTYPES_KEY],
-                'Allele Count': variant.variantStats[0].altAlleleCount,
-                'Allele Frequency': variant.variantStats[0].altAlleleFreq,
+                'Homozygotes Count': variant.variantStats[0] ? variant.variantStats[0].genotypesCount[HOMOZYGOTES_KEY] : '',
+                'Heterozygotes Count': variant.variantStats[0] ? variant.variantStats[0].genotypesCount[HETEROZYGOTES_KEY] : '',
+                'Missed Genotypes': variant.variantStats[0] ? variant.variantStats[0].genotypesCount[MISSED_GENOTYPES_KEY] : '',
+                'Allele Count': variant.variantStats[0] ? variant.variantStats[0].altAlleleCount : '',
+                'Allele Frequency': variant.variantStats[0] ? variant.variantStats[0].altAlleleFreq : '',
             };
         });
         let csv = Papa.unparse(data);

--- a/src/app/services/column-service.ts
+++ b/src/app/services/column-service.ts
@@ -8,12 +8,12 @@ export class ColumnService {
         'Alternate': (v: Variant) => v.alternate,
         'Type': (v: Variant) => v.type,
         'dbSNP': (v: Variant) => v.dbSNP,
-        'Homozygotes Count': (v: Variant) => v.variantStats[0].genotypesCount[HOMOZYGOTES_KEY],
-        'Heterozygotes Count': (v: Variant) => v.variantStats[0].genotypesCount[HETEROZYGOTES_KEY],
-        'Missed Genotypes': (v: Variant) => v.variantStats[0].genotypesCount[MISSED_GENOTYPES_KEY],
-        'Allele Count': (v: Variant) => v.variantStats[0].altAlleleCount,
-        'Allele Freq.': (v: Variant) => v.variantStats[0].altAlleleFreq.toExponential(4),
-        'Allele Scale': (v: Variant) => v.variantStats[0].altAlleleFreq
+        'Homozygotes Count': (v: Variant) => v.variantStats[0] ? v.variantStats[0].genotypesCount[HOMOZYGOTES_KEY] : null,
+        'Heterozygotes Count': (v: Variant) => v.variantStats[0] ? v.variantStats[0].genotypesCount[HETEROZYGOTES_KEY] : null,
+        'Missed Genotypes': (v: Variant) => v.variantStats[0] ? v.variantStats[0].genotypesCount[MISSED_GENOTYPES_KEY] : null,
+        'Allele Count': (v: Variant) => v.variantStats[0] ? v.variantStats[0].altAlleleCount : null,
+        'Allele Freq.': (v: Variant) => v.variantStats[0] ? v.variantStats[0].altAlleleFreq.toExponential(4) : null,
+        'Allele Scale': (v: Variant) => v.variantStats[0] ? v.variantStats[0].altAlleleFreq : null
     };
 
     private searchResultKeys: any[] = [
@@ -38,17 +38,29 @@ export class ColumnService {
         'Alternate': (v: Variant) => v.alternate,
         'Type': (v: Variant) => v.type,
         'dbSNP': (v: Variant) => v.dbSNP ? v.dbSNP.match(/rs(\d+)/)[1] : 0,
-        'Homozygotes Count': (v: Variant) =>
-            v.variantStats[0].genotypesCount[HOMOZYGOTES_KEY] ? v.variantStats[0].genotypesCount[HOMOZYGOTES_KEY] : 0,
-        'Heterozygotes Count': (v: Variant) =>
-            v.variantStats[0].genotypesCount[HETEROZYGOTES_KEY] ?
-                v.variantStats[0].genotypesCount[HETEROZYGOTES_KEY] : 0,
-        'Missed Genotypes': (v: Variant) =>
-            v.variantStats[0].genotypesCount[MISSED_GENOTYPES_KEY] ?
-                v.variantStats[0].genotypesCount[MISSED_GENOTYPES_KEY] : 0,
-        'Allele Count': (v: Variant) => v.variantStats[0].altAlleleCount,
-        'Allele Freq.': (v: Variant) => v.variantStats[0].altAlleleFreq,
-        'Allele Scale': (v: Variant) => v.variantStats[0].altAlleleFreq
+        'Homozygotes Count': (v: Variant) => {
+            if (!v.variantStats[0]) {
+                return 0;
+            }
+            return v.variantStats[0].genotypesCount[HOMOZYGOTES_KEY] ? v.variantStats[0].genotypesCount[HOMOZYGOTES_KEY] : 0;
+        },
+        'Heterozygotes Count': (v: Variant) => {
+            if (!v.variantStats[0]) {
+                return 0;
+            }
+            return v.variantStats[0].genotypesCount[HETEROZYGOTES_KEY] ?
+                v.variantStats[0].genotypesCount[HETEROZYGOTES_KEY] : 0;
+        },
+        'Missed Genotypes': (v: Variant) => {
+            if (!v.variantStats[0]) {
+                return 0;
+            }
+            return v.variantStats[0].genotypesCount[MISSED_GENOTYPES_KEY] ?
+                v.variantStats[0].genotypesCount[MISSED_GENOTYPES_KEY] : 0;
+        },
+        'Allele Count': (v: Variant) => v.variantStats[0] ? v.variantStats[0].altAlleleCount : 0,
+        'Allele Freq.': (v: Variant) => v.variantStats[0] ? v.variantStats[0].altAlleleFreq : 0,
+        'Allele Scale': (v: Variant) => v.variantStats[0] ? v.variantStats[0].altAlleleFreq : 0
     };
 
     private tooltips: any = {

--- a/src/app/services/filter.service.ts
+++ b/src/app/services/filter.service.ts
@@ -21,11 +21,11 @@ export class FilterService {
         'reference': (v: Variant) => v.reference,
         'alternate': (v: Variant) => v.alternate,
         'type': (v: Variant) => v.type,
-        'alleleFrequency': (v: Variant) => v.variantStats[0].altAlleleFreq,
-        'alleleCount': (v: Variant) => v.variantStats[0].altAlleleCount,
-        'homozygotesCount': (v: Variant) => v.variantStats[0].genotypesCount[HOMOZYGOTES_KEY],
-        'heterozygotesCount': (v: Variant) => v.variantStats[0].genotypesCount[HETEROZYGOTES_KEY],
-        'missedGenotypesCount': (v: Variant) => v.variantStats[0].genotypesCount[MISSED_GENOTYPES_KEY]
+        'alleleFrequency': (v: Variant) => v.variantStats[0] ? v.variantStats[0].altAlleleFreq : null,
+        'alleleCount': (v: Variant) => v.variantStats[0] ? v.variantStats[0].altAlleleCount : null,
+        'homozygotesCount': (v: Variant) => v.variantStats[0] ? v.variantStats[0].genotypesCount[HOMOZYGOTES_KEY] : null,
+        'heterozygotesCount': (v: Variant) => v.variantStats[0] ? v.variantStats[0].genotypesCount[HETEROZYGOTES_KEY] : null,
+        'missedGenotypesCount': (v: Variant) => v.variantStats[0] ? v.variantStats[0].genotypesCount[MISSED_GENOTYPES_KEY] : null
     };
 
     readonly operators: FilterOperator[] = ['<', '>', '=', '!='];

--- a/src/app/services/genome-browser/variant-track-service.ts
+++ b/src/app/services/genome-browser/variant-track-service.ts
@@ -163,7 +163,7 @@ export class VariantTrackService implements TrackService {
         let createPin = (variant: Variant) => {
             return new VariantPin(
                 variant.start,
-                variant.variantStats[0].altAlleleFreq,
+                variant.variantStats[0] ? variant.variantStats[0].altAlleleFreq : 0,
                 this.variantName(variant),
                 variant
             );
@@ -222,7 +222,7 @@ export class VariantTrackService implements TrackService {
                 that.createMethod.call(this, pins);
 
                 let homoz = pins.filter((d: VariantPin) => {
-                    return d.variant.variantStats[0].genotypesCount[HOMOZYGOTES_KEY];
+                    return d.variant.variantStats[0] ? d.variant.variantStats[0].genotypesCount[HOMOZYGOTES_KEY] : false;
                 });
                 homoz.select('line').attr('stroke', OVERLAY_COLOR);
                 homoz.select('circle').attr('fill', OVERLAY_COLOR);
@@ -234,7 +234,7 @@ export class VariantTrackService implements TrackService {
                 that.createMethod.call(this, pins);
 
                 let hetz = pins.filter((d: VariantPin) => {
-                    return d.variant.variantStats[0].genotypesCount[HETEROZYGOTES_KEY];
+                    return d.variant.variantStats[0] ? d.variant.variantStats[0].genotypesCount[HETEROZYGOTES_KEY] : false;
                 });
                 hetz.select('line').attr('stroke', OVERLAY_COLOR);
                 hetz.select('circle').attr('fill', OVERLAY_COLOR);


### PR DESCRIPTION
### What
Add null guards for stats and annotations

### Why
These fields may be null and the client should be able to still display the variant