### PR TITLE
fix variant view alternate display

### DIFF
--- a/src/app/components/pages/variant/variant.component.css
+++ b/src/app/components/pages/variant/variant.component.css
@@ -29,6 +29,10 @@
     flex-wrap: wrap;
 }
 
+.sibling .subgroup {
+    margin-right: 1rem;
+}
+
 .highlight-number {
     font-weight: bolder;
     font-size: large;

--- a/src/app/components/pages/variant/variant.component.ts
+++ b/src/app/components/pages/variant/variant.component.ts
@@ -66,8 +66,8 @@ export class VariantComponent implements OnInit, OnDestroy {
             let m = r.exec(params['query']);
             let chromo = m[1];
             let start = Number(m[2]);
-            let reference = m[3].replace('*', '');
-            let alternate = m[4].replace('*', '');
+            let reference = m[3];
+            let alternate = m[4];
 
             let sq = new SearchQuery(chromo, start, start, [new SearchOption('', 'returnAnnotations', [], 'true')]);
             this.getVariant(sq, reference, alternate);
@@ -113,7 +113,7 @@ export class VariantComponent implements OnInit, OnDestroy {
                 this.error = 'Found more than one variant for query';
             } else if (vf.length > 0) {
                 this.variant = vf[0];
-                if (this.variant.alternate.length !== 1) {
+                if (this.variant.alternate.length !== 1 || this.variant.alternate === '*') {
                     this.beaconSupported = false;
                 } else {
                     this.beacons = this.bss.searchBeacon(this.beaconQuery(this.variant));

--- a/src/app/model/variant.ts
+++ b/src/app/model/variant.ts
@@ -27,8 +27,6 @@ export class Variant {
     }
 
     static displayName(variant: Variant) {
-        let r = variant.reference ? variant.reference : '*';
-        let a = variant.alternate ? variant.alternate : '*';
-        return `${ variant.chromosome }-${ variant.start }-${ r }-${ a }`;
+        return `${ variant.chromosome }-${ variant.start }-${ variant.reference }-${ variant.alternate }`;
     }
 }

--- a/src/app/shared/meta-information.css
+++ b/src/app/shared/meta-information.css
@@ -23,3 +23,7 @@
 .detail-value i {
     margin-left: 5px;
 }
+
+.detail-value {
+    word-break: break-all;
+}


### PR DESCRIPTION
### what
- fix https://github.com/shusson/sgc/issues/18
- scroll meta-information subview when there is overflow
- handle asterix(*) alternate values in the variant view

### why
- allow users to view variants with extremely long alternates
- Allow users to navigate to a variant that has an alternate of '*'
