### PR TITLE
hide the genome browser if there are too many variants to display.

### DIFF
--- a/src/app/components/parts/search-results/search-results.component.html
+++ b/src/app/components/parts/search-results/search-results.component.html
@@ -20,6 +20,10 @@
         </mat-tab>
     </mat-tab-group>
 
-    <app-genome-browser-resizable></app-genome-browser-resizable>
+    <div *ngIf="variants.length > 10000" class="message message-error">
+        This region contains too many variants to visualize with our genome browser, please choose a smaller region like:
+        <a (click)="goToSmallerRegion()">{{searchService.getSmallerRegionString()}}</a>
+    </div>
+    <app-genome-browser-resizable *ngIf="variants.length < 10000"></app-genome-browser-resizable>
     <app-variants-table [variants]="variants"></app-variants-table>
 </div>

--- a/src/app/components/parts/search-results/search-results.component.ts
+++ b/src/app/components/parts/search-results/search-results.component.ts
@@ -8,7 +8,7 @@ import { SearchBarService } from '../../../services/search-bar-service';
 import { VariantAutocompleteResult } from '../../../model/autocomplete-result';
 import { Gene } from '../../../model/gene';
 import { Region } from '../../../model/region';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 
 @Component({
     selector: 'app-search-results',
@@ -29,6 +29,7 @@ export class SearchResultsComponent implements OnInit, OnDestroy, AfterViewInit 
     constructor(public searchService: VariantSearchService,
                 private cd: ChangeDetectorRef,
                 private searchBarService: SearchBarService,
+                private router: Router,
                 private route: ActivatedRoute) {
     }
 
@@ -92,6 +93,11 @@ export class SearchResultsComponent implements OnInit, OnDestroy, AfterViewInit 
                 this.showClinicalFilters();
             }, 200)
         }
+    }
+
+    goToSmallerRegion() {
+        const obj = {query: this.searchService.getSmallerRegionString(), timestamp: Date.now()};
+        this.router.navigate(['/search/results', obj]);
     }
 
     tabSelected(v) {

--- a/src/app/services/variant-search-service.ts
+++ b/src/app/services/variant-search-service.ts
@@ -78,6 +78,10 @@ export class VariantSearchService {
         return new Region(this.lastQuery.chromosome, this.lastQuery.start, this.lastQuery.end);
     }
 
+    getSmallerRegionString() {
+        return `${this.lastQuery.chromosome}:${this.lastQuery.start}-${this.lastQuery.start + 100000}`;
+    }
+
     hasMoved() {
         return this.startingRegion.start !== this.lastQuery.start || this.startingRegion.end !== this.lastQuery.end;
     }


### PR DESCRIPTION
### what 
Hide genome browser for queries with large amount of variants.

### why
Large number of variants >10000 cause performance issues because the genome browser does not do any smart smoothing at the moment.