### PR TITLE
update ports to use common values so to avoid firewall issues

### DIFF
--- a/src/environments/environment.dev.ts
+++ b/src/environments/environment.dev.ts
@@ -7,7 +7,7 @@ export const environment = {
     auth0Domain: 'sgc.au.auth0.com',
     beaconNetworkUrl: 'https://beacon-network.org/api',
     // vsalUrl: 'http://localhost:3000',
-    vsalUrl: 'https://services.vectis-api.com:444/variants',
+    vsalUrl: 'https://services.vectis-api.com:80/variants',
     // elasticUrl: 'http://localhost:328v40',
     elasticUrl: 'https://dr-sgc.kccg.garvan.org.au/_elasticsearch',
     durlUrl: 'https://wt-ec1ac815dce38c76c2e7662693b82189-0.run.webtask.io/durl-dev',
@@ -16,7 +16,7 @@ export const environment = {
     mapd: {
         protocol: 'https',
         host: 'mapd.vectis-api.com',
-        port: '445',
+        port: '443',
         dbName: 'mapd',
         user: 'mapd',
         pwd: 'HyperInteractive',

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -6,7 +6,7 @@ export const environment = {
     auth0ClientId: 'KLhFZDgUFeUyO6CnslMoGAoQ1lV0uWzM',
     auth0Domain: 'sgc.au.auth0.com',
     beaconNetworkUrl: 'https://beacon-network.org/api',
-    vsalUrl: 'https://services.vectis-api.com:444/variants',
+    vsalUrl: 'https://services.vectis-api.com:80/variants',
     elasticUrl: 'https://dr-sgc.kccg.garvan.org.au/_elasticsearch',
     durlUrl: 'https://wt-ec1ac815dce38c76c2e7662693b82189-0.run.webtask.io/durl',
     sentryUrl: 'https://4126e3ee842b4f079400ccf84980e84e@sentry.io/158608',
@@ -14,7 +14,7 @@ export const environment = {
     mapd: {
         protocol: 'https',
         host: 'mapd.vectis-api.com',
-        port: '445',
+        port: '443',
         dbName: 'mapd',
         user: 'mapd',
         pwd: 'HyperInteractive',

--- a/src/environments/environment.staging.ts
+++ b/src/environments/environment.staging.ts
@@ -6,7 +6,7 @@ export const environment = {
     auth0ClientId: 'eS2HA6aSYnxCXFvo9bzHpV1DI6H1yw0l',
     auth0Domain: 'sgc.au.auth0.com',
     beaconNetworkUrl: 'https://beacon-network.org/api',
-    vsalUrl: 'https://services.vectis-api.com:444/variants',
+    vsalUrl: 'https://services.vectis-api.com:80/variants',
     elasticUrl: 'https://dr-sgc.kccg.garvan.org.au/_elasticsearch',
     durlUrl: 'https://wt-ec1ac815dce38c76c2e7662693b82189-0.run.webtask.io/durl-dev',
     sentryUrl: 'https://90b2013bdfef4fef9491990e6ad379c6@sentry.io/158605',
@@ -14,7 +14,7 @@ export const environment = {
     mapd: {
         protocol: 'https',
         host: 'mapd.vectis-api.com',
-        port: '445',
+        port: '443',
         dbName: 'mapd',
         user: 'mapd',
         pwd: 'HyperInteractive',


### PR DESCRIPTION
### What
Update ports to use common values like 80 and 443.
 
### Why
There are organisations that block outgoing traffic except on common ports like 443 or 80 and some users were not able to reach our services.