### PR TITLE
prevent genome browser from updating if there are too many variants t…

### DIFF
--- a/src/app/components/parts/search-results/search-results.component.html
+++ b/src/app/components/parts/search-results/search-results.component.html
@@ -24,6 +24,6 @@
         This region contains too many variants to visualize with our genome browser, please choose a smaller region like:
         <a (click)="goToSmallerRegion()">{{searchService.getSmallerRegionString()}}</a>
     </div>
-    <app-genome-browser-resizable *ngIf="variants.length < 10000"></app-genome-browser-resizable>
+    <app-genome-browser-resizable *ngIf="variants.length <= maximumNumberOfVariants"></app-genome-browser-resizable>
     <app-variants-table [variants]="variants"></app-variants-table>
 </div>

--- a/src/app/components/parts/search-results/search-results.component.ts
+++ b/src/app/components/parts/search-results/search-results.component.ts
@@ -1,5 +1,6 @@
 import { Component, ChangeDetectorRef, OnDestroy, Input, Output, EventEmitter, OnInit, AfterViewInit } from '@angular/core';
 import { Variant } from '../../../model/variant';
+import { MAXIMUM_NUMBER_OF_VARIANTS } from '../../../services/cttv-service';
 
 import { VariantSearchService } from '../../../services/variant-search-service';
 import { Subscription } from 'rxjs/Subscription';
@@ -23,6 +24,7 @@ export class SearchResultsComponent implements OnInit, OnDestroy, AfterViewInit 
     public variants: Variant[] = [];
     public loadingVariants = false;
     private subscriptions: Subscription[] = [];
+    maximumNumberOfVariants = MAXIMUM_NUMBER_OF_VARIANTS;
     selectedTabIndex = 0;
     timeout = null;
 

--- a/src/app/services/cttv-service.ts
+++ b/src/app/services/cttv-service.ts
@@ -30,6 +30,8 @@ import * as tooltip from 'tnt.tooltip';
  limitations under the License.
  */
 
+export const MAXIMUM_NUMBER_OF_VARIANTS = 10000;
+
 @Injectable()
 export class CttvService {
 
@@ -208,6 +210,11 @@ export class CttvService {
     }
 
     static filterValuesAndLabelGroups(values: any[], xScale: any) {
+        if (values.length > MAXIMUM_NUMBER_OF_VARIANTS) {
+            values.length = 0;
+            return;
+        }
+
         const lim = 20;
         const deltaXLimit = (values.length / 1000) + 5;
         const deltaValLimit = 0.01;


### PR DESCRIPTION
### What:
Prevent any genome browser logic from happening if there are too many variants (> 10000) to display.

### Why:
If you dragged the browser and triggered an update with >10000 variants, the browser would hang.