### PR TITLE
fix csp on mobile devices

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
 <head>
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self';
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self' blob: data:;
     script-src 'self' 'unsafe-eval' https://cdn.logrocket.com https://cdn.au.auth0.com https://canny.io;
     style-src 'self' 'unsafe-inline' *.googleapis.com *.gstatic.com;
     connect-src https: http: ws:;


### PR DESCRIPTION
### What
update defaults

### Why
some mobile browsers do not currently support `worker-src`