### PR TITLE
fix clinical filtering for large regions

### DIFF
--- a/src/app/components/parts/clincal-filtering/clincal-filtering.component.ts
+++ b/src/app/components/parts/clincal-filtering/clincal-filtering.component.ts
@@ -4,7 +4,6 @@ import * as dc from 'dc';
 import * as crossfilter from 'crossfilter2';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Subscription } from 'rxjs/Subscription';
-import { element } from 'protractor';
 
 export class ClinicalChart {
 

--- a/src/app/services/clinapi.service.ts
+++ b/src/app/services/clinapi.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, OnDestroy } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
 import { Subject } from 'rxjs/Subject';
+import { MAXIMUM_NUMBER_OF_VARIANTS } from './cttv-service';
 import { VariantTrackService } from './genome-browser/variant-track-service';
 import { FAKE_CLINICAL_DATA } from '../mocks/clindata';
 import { VariantSearchService } from './variant-search-service';
@@ -19,18 +20,21 @@ export class ClinapiService implements OnDestroy {
         this.subs.push(this.changes.debounceTime(300).subscribe(v => {
             this.vss.filter = this.filterVariants;
             this.samples = this.samplesGroup.all().filter(s => s.value > 0).map(s => s.key);
-
             const loc = {
                 from: this.vss.lastQuery.start,
                 to: this.vss.lastQuery.end,
             };
 
-            vts.track.data().call(vts.track, {
-                'loc' : loc,
-                'on_success' : () => {
-                    vts.track.display().update.call(vts.track, loc);
-                }
-            });
+            if (this.vss.variants.length > MAXIMUM_NUMBER_OF_VARIANTS) {
+                this.vss.getVariants(this.vss.lastQuery);
+            } else {
+                vts.track.data().call(vts.track, {
+                    'loc' : loc,
+                    'on_success' : () => {
+                        vts.track.display().update.call(vts.track, loc);
+                    }
+                });
+            }
         }));
     }
 


### PR DESCRIPTION
### What
If the genome browser is hidden, then update the variants directly through the variant search service.

### Why
For large regions we hide the genome browser and cannot use its update method to filter the variants. 